### PR TITLE
Add `Checkout` product scanning and total pricing logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 
 gem 'pg'
 gem 'activerecord'
+gem 'activesupport'
 
 group :test, :development do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  activesupport
   byebug
   pg
   rspec

--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -1,10 +1,66 @@
+require 'active_support'
+require 'product'
+
 class Checkout
+  attr_reader :products
+
   def initialize(pricing_rules)
+    @products = {}
+    @rules = pricing_rules
   end
 
   def scan(code)
+    increment_product_count(code)
   end
 
   def total
+    products.sum(&method(:product_total)).to_f
+  end
+
+  private
+
+  def increment_product_count(code)
+    @products[code] = 0 unless @products.has_key?(code)
+    @products[code] += 1
+  end
+
+  def product_total(args)
+    code, count = args
+    return product_price(code) * count unless codes_with_rules.include?(code)
+    price_with_rules(code, count)
+  end
+
+  def product_price(code)
+    Product.where(code: code).pluck(:price).first
+  end
+
+  def codes_with_rules
+    @rules.map { |rule| rule[:code] }
+  end
+
+  def price_with_rules(code, count)
+    base_price = product_price(code)
+    discount_class(code).new.process(count, base_price, discount_attributes(code))
+  end
+
+  def discount_attributes(code)
+    discount_rule(code)[:attributes]
+  end
+
+  def discount_type(code)
+    discount_rule(code)[:rule]
+  end
+
+  def discount_rule(code)
+    @rules.select { |rule| rule[:code] == code }.first
+  end
+
+  def discount_class(code)
+    begin
+      class_name = ActiveSupport::Inflector.classify(discount_type(code))
+      ActiveSupport::Inflector.constantize("DiscountTypes::#{class_name}")
+    rescue NameError
+      raise Exception.new("Unregistered discount type #{class_name} for product: #{code}")
+    end
   end
 end

--- a/lib/discount_types/bulk_pricing.rb
+++ b/lib/discount_types/bulk_pricing.rb
@@ -1,0 +1,12 @@
+require 'bigdecimal'
+module DiscountTypes
+  class BulkPricing
+    def process(count, base_price, attrs)
+      min_units = attrs[:min_units]
+      percentage = attrs[:percentage]
+
+      return count * base_price unless count >= min_units
+      count * base_price * (1 - percentage)
+    end
+  end
+end

--- a/lib/discount_types/bundled_units_pricing.rb
+++ b/lib/discount_types/bundled_units_pricing.rb
@@ -1,0 +1,24 @@
+module DiscountTypes
+  class BundledUnitsPricing
+    def process(count, base_price, attrs)
+      base_price * total_units(count, attrs)
+    end
+
+    private
+
+    def total_units(count, attrs)
+      divisor = attrs[:bundle_divisor]
+      multiplier = attrs[:bundle_multiplier]
+
+      bundled_units(count, divisor, multiplier) + remainder_units(count, divisor)
+    end
+
+    def bundled_units(count, bundle_divisor, bundle_multiplier)
+      ( count / bundle_divisor ) * bundle_multiplier
+    end
+
+    def remainder_units(count, bundle_divisor)
+      count % bundle_divisor
+    end
+  end
+end

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -1,45 +1,96 @@
-require 'checkout'
+require 'spec_helper'
 
 RSpec.describe Checkout do
-  let(:default_rules) { {} }
-  subject {Checkout.new(default_rules) }
-
-  it "sums correctly individual items" do
-
-    subject.scan("VOUCHER")
-    subject.scan("TSHIRT")
-    subject.scan("MUG")
-
-    expect(subject.total).to eq(32.50)
+  let(:default_rules) do
+    [
+      {
+        code: 'TSHIRT',
+        rule: 'bulk_pricing',
+        attributes: {
+          min_units: 3,
+          percentage: 0.05
+        }
+      },
+      {
+        code: 'VOUCHER',
+        rule: 'bundled_units_pricing',
+        attributes: {
+          bundle_divisor: 2,
+          bundle_multiplier: 1
+        }
+      }
+    ]
   end
 
-  it "applies the 2x1 discount on VOUCHER items" do
-    subject.scan("VOUCHER")
-    subject.scan("TSHIRT")
-    subject.scan("VOUCHER")
-
-    expect(subject.total).to eq(25.00)
+  before(:all) do
+    Product.create(name: 'Cabify Awesome T-Shirt', code: 'TSHIRT', price: 20.0)
+    Product.create(name: 'Cabify Awesome Mug', code: 'MUG', price: 7.5)
+    Product.create(name: 'Cabify Awesome Voucher', code: 'VOUCHER', price: 5.0)
   end
 
-  it "applies the bulk discount on TSHIRT items" do
-    subject.scan("TSHIRT")
-    subject.scan("TSHIRT")
-    subject.scan("TSHIRT")
-    subject.scan("VOUCHER")
-    subject.scan("TSHIRT")
+  subject { Checkout.new(default_rules) }
 
-    expect(subject.total).to eq(81.00)
+  describe "Saves products scanned during the checkout process" do
+    it "saves the product code" do
+      subject.scan("TSHIRT")
+      expect(subject.products).to have_key("TSHIRT")
+      expect(subject.products["TSHIRT"]).to eq(1)
+    end
+
+    it "increments the counter on an existing product code" do
+      subject.scan("TSHIRT")
+      expect(subject.products["TSHIRT"]).to eq(1)
+
+      subject.scan("TSHIRT")
+      expect(subject.products["TSHIRT"]).to eq(2)
+    end
+
+    it "saves multiple product codes" do
+      subject.scan("TSHIRT")
+      subject.scan("MUG")
+
+      expect(subject.products["TSHIRT"]).to eq(1)
+      expect(subject.products["MUG"]).to eq(1)
+    end
   end
 
-  it "applies the different discounts on a multi-items checkout" do
-    subject.scan("VOUCHER")
-    subject.scan("TSHIRT")
-    subject.scan("VOUCHER")
-    subject.scan("VOUCHER")
-    subject.scan("MUG")
-    subject.scan("TSHIRT")
-    subject.scan("TSHIRT")
+  describe "Applies the pricing rules to the scanned items" do
+    it "sums the total when there are no repeat items" do
+      subject.scan("VOUCHER")
+      subject.scan("TSHIRT")
+      subject.scan("MUG")
 
-    expect(subject.total).to eq(74.50)
+      expect(subject.total).to eq(32.50)
+    end
+
+    it "sums the total when applying a 2x1 discount on VOUCHER items" do
+      subject.scan("VOUCHER")
+      subject.scan("TSHIRT")
+      subject.scan("VOUCHER")
+
+      expect(subject.total).to eq(25.00)
+    end
+
+    it "sums the total when doing a bulk discount on TSHIRT items" do
+      subject.scan("TSHIRT")
+      subject.scan("TSHIRT")
+      subject.scan("TSHIRT")
+      subject.scan("VOUCHER")
+      subject.scan("TSHIRT")
+
+      expect(subject.total).to eq(81.00)
+    end
+
+    it "sums the total when applying multiple pricing rules" do
+      subject.scan("VOUCHER")
+      subject.scan("TSHIRT")
+      subject.scan("VOUCHER")
+      subject.scan("VOUCHER")
+      subject.scan("MUG")
+      subject.scan("TSHIRT")
+      subject.scan("TSHIRT")
+
+      expect(subject.total).to eq(74.50)
+    end
   end
 end


### PR DESCRIPTION
Adds the product scanning and total pricing logic by applying discount rules to a list of scanned products.